### PR TITLE
build(ci): migrate CI from Docker image to devcontainers/ci

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,10 +7,6 @@ on:
   - pull_request
   - release
 
-env:
-  CMAKE_BUILD_TYPE: Release
-  DOCKER_IMAGE: ptrnull233/simple_kernel:latest
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,29 +22,23 @@ jobs:
           submodules: recursive
 
       - name: x86_64
-        uses: addnab/docker-run-action@v3
+        uses: devcontainers/ci@v0.3
         with:
-          image: ${{ env.DOCKER_IMAGE }}
-          options: -v ${{ github.workspace }}:/root -e CMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }}
-          run: |
+          runCmd: |
             cmake --preset=build_x86_64
             cmake --build build_x86_64 --target SimpleKernel unit-test coverage docs
 
       - name: riscv64
-        uses: addnab/docker-run-action@v3
+        uses: devcontainers/ci@v0.3
         with:
-          image: ${{ env.DOCKER_IMAGE }}
-          options: -v ${{ github.workspace }}:/root -e CMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }}
-          run: |
+          runCmd: |
             cmake --preset=build_riscv64
             cmake --build build_riscv64 --target SimpleKernel
 
       - name: aarch64
-        uses: addnab/docker-run-action@v3
+        uses: devcontainers/ci@v0.3
         with:
-          image: ${{ env.DOCKER_IMAGE }}
-          options: -v ${{ github.workspace }}:/root -e CMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }}
-          run: |
+          runCmd: |
             cmake --preset=build_aarch64
             cmake --build build_aarch64 --target SimpleKernel
 
@@ -64,8 +54,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ${{ github.workspace }}/docs/html
-
-      # - name: Super-Linter
-      #   uses: super-linter/super-linter@v7.2.0
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- 将 CI 从 `addnab/docker-run-action` + `ptrnull233/simple_kernel:latest`（GCC 13）迁移到 `devcontainers/ci@v0.3`
- CI 现在使用项目的 `.devcontainer/Dockerfile`（GCC 14），与本地开发环境一致

## Motivation

PR #195 合入后 CI 构建失败，因为代码使用了 C++23 deducing this（`this auto self`）语法，需要 GCC 14+，但旧 Docker 镜像仅包含 GCC 13。

## Changes

| Before | After |
|--------|-------|
| `addnab/docker-run-action@v3` | `devcontainers/ci@v0.3` |
| `ptrnull233/simple_kernel:latest` (GCC 13) | `.devcontainer/Dockerfile` (GCC 14) |
| 环境变量传递 `CMAKE_BUILD_TYPE` | 使用 preset 默认配置 |